### PR TITLE
Use safe_mode when flag is set on boot for OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,9 @@ out/safety-dance/SafetyDance.app/Info.plist: darwin-bootstrap/safety-dance/Info.
 	cp darwin-bootstrap/safety-dance/white.png out/safety-dance/SafetyDance.app/Default@2x.png
 safety-dance: out/safety-dance/SafetyDance.app/SafetyDance out/safety-dance/SafetyDance.app/Info.plist
 all: safety-dance
+endif
 
+# Common Bootstrap
 out/posixspawn-hook.dylib: darwin-bootstrap/posixspawn-hook.c out/libsubstitute.dylib
 	$(CC) -dynamiclib -o $@ $< -Lout -lsubstitute
 out/bundle-loader.dylib: darwin-bootstrap/bundle-loader.c darwin-bootstrap/substituted-messages.h out/libsubstitute.dylib
@@ -200,7 +202,6 @@ out/inject-into-launchd: darwin-bootstrap/inject-into-launchd.c darwin-bootstrap
 out/substituted: darwin-bootstrap/substituted*
 	$(CC) -o $@ darwin-bootstrap/substituted{.c,-plist-loader.m} -framework Foundation -framework CoreFoundation -lbsm -fobjc-arc
 all: out/posixspawn-hook.dylib out/bundle-loader.dylib out/unrestrict out/inject-into-launchd out/substituted
-endif
 
 
 clean:

--- a/darwin-bootstrap/bundle-loader.c
+++ b/darwin-bootstrap/bundle-loader.c
@@ -160,6 +160,11 @@ invalid:
 static kern_return_t substituted_hello(mach_port_t service, int proto_version,
                                        const char *argv0, void **bundle_list_p,
                                        size_t *bundle_list_size_p) {
+                                           
+    if (argv0 == NULL) {
+        return KERN_INVALID_ARGUMENT;
+    }
+    
     struct {
         mach_msg_header_t hdr;
         union {
@@ -176,6 +181,7 @@ static kern_return_t substituted_hello(mach_port_t service, int proto_version,
     buf.hdr.msgh_reserved = 0;
     buf.hdr.msgh_id = SUBSTITUTED_MSG_HELLO;
     buf.u.req.proto_version = proto_version;
+    
     strlcpy(buf.u.req.argv0, argv0, sizeof(buf.u.req.argv0));
     size_t size = sizeof(buf.hdr) +
                   offsetof(struct substituted_msg_body_hello, argv0) +

--- a/darwin-bootstrap/bundle-loader.c
+++ b/darwin-bootstrap/bundle-loader.c
@@ -27,7 +27,7 @@ static bool pop(const void **buf, const void *end,
     *buf += sizeof(*op);
     *opc = op->opc;
     if ((size_t) (end - *buf) <= op->namelen ||
-        ((const char *) buf)[op->namelen] != '\0')
+        ((const char *) *buf)[op->namelen] != '\0')
         return false;
     *name = *buf;
     *buf += op->namelen + 1;

--- a/darwin-bootstrap/posixspawn-hook.c
+++ b/darwin-bootstrap/posixspawn-hook.c
@@ -306,7 +306,7 @@ static int hook_posix_spawn_generic(__typeof__(posix_spawn) *old,
     bool need_unrestrict = looks_restricted(path);
 
     /* TODO skip this if Substrate is doing it anyway */
-    bool was_suspended = false;
+    bool was_suspended;
     
     if (need_unrestrict) {
         was_suspended = flags & POSIX_SPAWN_START_SUSPENDED;

--- a/darwin-bootstrap/posixspawn-hook.c
+++ b/darwin-bootstrap/posixspawn-hook.c
@@ -32,6 +32,7 @@
 #include <arpa/inet.h>
 #include <libkern/OSByteOrder.h>
 #include <sys/sysctl.h>
+#include <TargetConditionals.h>
 
 extern char ***_NSGetEnviron(void);
 
@@ -234,13 +235,13 @@ static int hook_posix_spawn_generic(__typeof__(posix_spawn) *old,
     
 #if !TARGET_OS_IPHONE
     // Always disable substitute in safe mode on OSX
-    int safeBoot;
+    int safe_boot;
     int mib_name[2] = { CTL_KERN, KERN_SAFEBOOT };
     size_t length = sizeof(safeBoot);
-    if (!sysctl(mib_name, 2, &safeBoot, &length, NULL, 0)) {
-        safe_mode = safe_mode || safeBoot == 1;
+    if (!sysctl(mib_name, 2, &safe_boot, &length, NULL, 0)) {
+        safe_mode = safe_mode || safe_boot == 1;
     } else {
-        // Couldn't find safe boot flag
+        safe_mode = false;
     }
 #endif
     

--- a/darwin-bootstrap/posixspawn-hook.c
+++ b/darwin-bootstrap/posixspawn-hook.c
@@ -273,6 +273,8 @@ static int hook_posix_spawn_generic(__typeof__(posix_spawn) *old,
         if (newp != newp_orig)
             *newp++ = ':';
         newp = stpcpy(newp, dylib_to_add);
+    } else {
+        newp = stpcpy(newp, "\0");
     }
     if (IB_VERBOSE)
         ib_log("using %s", new);

--- a/darwin-bootstrap/posixspawn-hook.c
+++ b/darwin-bootstrap/posixspawn-hook.c
@@ -255,9 +255,9 @@ static int hook_posix_spawn_generic(__typeof__(posix_spawn) *old,
         /* append if it isn't one of ours */
         bool is_substitute =
             (next - p == sizeof(bl_dylib) - 1 &&
-             !memcmp(next, bl_dylib, sizeof(bl_dylib) - 1)) ||
+             !memcmp(p, bl_dylib, sizeof(bl_dylib) - 1)) ||
             (next - p == sizeof(psh_dylib) - 1 &&
-             !memcmp(next, psh_dylib, sizeof(psh_dylib) - 1));
+             !memcmp(p, psh_dylib, sizeof(psh_dylib) - 1));
         if (!is_substitute) {
             if (newp != newp_orig)
                 *newp++ = ':';

--- a/darwin-bootstrap/posixspawn-hook.c
+++ b/darwin-bootstrap/posixspawn-hook.c
@@ -305,7 +305,8 @@ static int hook_posix_spawn_generic(__typeof__(posix_spawn) *old,
     bool need_unrestrict = looks_restricted(path);
 
     /* TODO skip this if Substrate is doing it anyway */
-    bool was_suspended;
+    bool was_suspended = false;
+    
     if (need_unrestrict) {
         was_suspended = flags & POSIX_SPAWN_START_SUSPENDED;
         flags |= POSIX_SPAWN_START_SUSPENDED;


### PR DESCRIPTION
When the user boots into safe mode with the -x flag or otherwise on OS X, substitute should be disabled. Also, there's a commit in here which makes the bootstrap stuff build no matter what (mostly so I could test on OS X, which I'm still in the process of setting up a VM to do so), I don't know if that goes according to your plan for this project, though.

I haven't tested this bit of code in the context of substitute, but I can affirm that it otherwise works as far as detecting safe mode.

Also, this has a bug fix for bundle-loader.c in which the test for the char after namelen characters in the name is equal to '\0' would usually fail.