### PR TITLE
Added ARM32 support for transforming branches at function beginning

### DIFF
--- a/lib/arm/arch-dis.h
+++ b/lib/arm/arch-dis.h
@@ -62,4 +62,4 @@ static inline void advance_it_cond(struct arch_dis_ctx *ctx) {
  * to keep going */
 #define CC_ALREADY_IN_IT (CC_CONDITIONAL | 0x800)
 /* CBZ/CBNZ is rewritten */
-#define CC_CBXZ          (CC_CONDITIONAL | 0xc00)
+#define CC_CBXZ          (CC_CONDITIONAL | 0x1000)

--- a/lib/arm/jump-patch.h
+++ b/lib/arm/jump-patch.h
@@ -14,6 +14,6 @@ static inline int jump_patch_size(uint_tptr pc,
 static inline void make_jump_patch(void **codep, uint_tptr pc,
                                    uint_tptr dpc,
                                    struct arch_dis_ctx arch) {
-    struct assemble_ctx actx = {codep, pc, arch.pc_low_bit, 0xe};
+    struct assemble_ctx actx = {codep, *codep, pc, arch.pc_low_bit, 0xe};
     LDR_PC(actx, dpc);
 }

--- a/lib/hook-functions.c
+++ b/lib/hook-functions.c
@@ -138,6 +138,7 @@ int substitute_hook_functions(const struct substitute_function_hook *hooks,
     bool thread_safe = !(options & SUBSTITUTE_NO_THREAD_SAFETY);
     if (thread_safe && !pthread_main_np())
         return SUBSTITUTE_ERR_NOT_ON_MAIN_THREAD;
+    bool relaxed = !!(options & SUBSTITUTE_RELAXED);
 
     if (recordp)
         *recordp = NULL;
@@ -224,7 +225,8 @@ int substitute_hook_functions(const struct substitute_function_hook *hooks,
         if ((ret = transform_dis_main(code, &trampoline_ptr, pc_patch_start,
                                       &pc_patch_end, (uintptr_t) trampoline_ptr,
                                       &arch, hi->offset_by_pcdiff,
-                                      thread_safe ? TRANSFORM_DIS_BAN_CALLS : 0)))
+                                      (thread_safe ? TRANSFORM_DIS_BAN_CALLS : 0) | 
+                                      (relaxed ? 0 : TRANSFORM_DIS_REL_JUMPS))))
             goto end;
 
         uintptr_t dpc = pc_patch_end;

--- a/lib/substitute.h
+++ b/lib/substitute.h
@@ -103,6 +103,7 @@ struct substitute_function_hook {
 /* substitute_hook_functions options */
 enum {
     SUBSTITUTE_NO_THREAD_SAFETY = 1,
+    SUBSTITUTE_RELAXED = 2,
 };
 
 /* Patch the machine code of the specified functions to redirect them to the
@@ -124,6 +125,9 @@ enum {
  *
  * You can disable the main thread check and all synchronization by passing
  * SUBSTITUTE_NO_THREAD_SAFETY.
+ * 
+ * You can relax the disassembly engine (at the risk of possible incorrect 
+ * results) to be compatible with more functions by passing SUBSTITUTE_RELAXED.
  *
  * Why not just use a mutex to prevent deadlock?  That would work between
  * multiple calls into libsubstitute, but there may be other libraries that

--- a/lib/transform-dis.c
+++ b/lib/transform-dis.c
@@ -24,6 +24,7 @@ struct transform_dis_ctx {
     bool force_keep_transforming;
 
     bool ban_calls; /* i.e. trying to be thread safe */
+    bool ban_jumps; /* allow transforming rel branches at beginning */
 
     void **rewritten_ptr_ptr;
     void *write_newop_here;
@@ -78,7 +79,7 @@ static void transform_dis_branch_top(struct transform_dis_ctx *ctx,
     }
     if (cc & CC_CALL) {
         transform_dis_indirect_call(ctx);
-    } else {
+    } else if (ctx->ban_jumps) {
         transform_dis_ret(ctx);
     }
 }
@@ -102,6 +103,7 @@ int transform_dis_main(const void *restrict code_ptr,
     ctx.base.pc = pc_patch_start;
     ctx.arch = *arch_ctx_p;
     ctx.ban_calls = options & TRANSFORM_DIS_BAN_CALLS;
+    ctx.ban_jumps = options & TRANSFORM_DIS_REL_JUMPS;
     /* data is written to rewritten both by this function directly and, in case
      * additional scaffolding is needed, by arch-specific transform_dis_* */
     ctx.rewritten_ptr_ptr = rewritten_ptr_ptr;

--- a/lib/transform-dis.h
+++ b/lib/transform-dis.h
@@ -4,6 +4,7 @@
 #include "dis.h"
 
 #define TRANSFORM_DIS_BAN_CALLS 1
+#define TRANSFORM_DIS_REL_JUMPS 2
 
 int transform_dis_main(const void *restrict code_ptr,
                        void **restrict rewritten_ptr_ptr,


### PR DESCRIPTION
Fixed defination of CC_CBXZ collides with other bits
Fixed incorrect pc value in tdctx_to_actx
Fixed ARM32 handling of CC_CBXZ (uses incorrect field in ctx->base)
Fixed ARM32 transform_dis_branch incorrectly trashing LR for non-call based jumps
Fixed ARM32 make_jump_patch not updated to use new assemble_ctx
Added new option SUBSTITUTE_RELAXED to relax the disassembly engine
Currently SUBSTITUTE_RELAXED only disables TRANSFORM_DIS_REL_JUMPS so jumps at the beginning of functions are allowed