### PR TITLE
fix macox 10.13 or later

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 *.swp
 out
+.vscode
+Makefile
+*.log
+config.status
+mconfig.pyc

--- a/configure
+++ b/configure
@@ -110,6 +110,7 @@ mconfig.build_and_link_c_objs(
         '(src)/lib/darwin/interpose.c',
         '(src)/lib/darwin/objc-asm.S',
         '(src)/lib/darwin/objc.c',
+        '(src)/lib/darwin/macho.c',
         '(src)/lib/darwin/read.c',
         '(src)/lib/darwin/substrate-compat.c',
         '(src)/lib/darwin/execmem.c',

--- a/lib/darwin/find-syms.c
+++ b/lib/darwin/find-syms.c
@@ -11,7 +11,7 @@
 #include "substitute-internal.h"
 #include "dyld_cache_format.h"
 
-extern const struct dyld_all_image_infos *_dyld_get_all_image_infos();
+extern struct dyld_all_image_infos * my_get_all_image_infos();
 
 static pthread_once_t dyld_inspect_once = PTHREAD_ONCE_INIT;
 /* and its fruits: */
@@ -280,7 +280,7 @@ end:
  */
 
 static void inspect_dyld() {
-    const struct dyld_all_image_infos *aii = _dyld_get_all_image_infos();
+    const struct dyld_all_image_infos *aii = my_get_all_image_infos();
     const void *dyld_hdr = aii->dyldImageLoadAddress;
 
     const char *names[2] = { "__ZNK16ImageLoaderMachO8getSlideEv",

--- a/lib/darwin/inject.c
+++ b/lib/darwin/inject.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 
-extern const struct dyld_all_image_infos *_dyld_get_all_image_infos();
+extern struct dyld_all_image_infos * my_get_all_image_infos();
 
 #define DEFINE_STRUCTS
 
@@ -104,7 +104,7 @@ static int find_foreign_images(mach_port_t task,
      * look up the symbols locally and don't have to do the rest of the
      * syscalls... not sure if this is any faster, but whatever. */
     if (FIELD(version) >= 13) {
-        const struct dyld_all_image_infos *local_aii = _dyld_get_all_image_infos();
+        const struct dyld_all_image_infos *local_aii = my_get_all_image_infos();
         if (local_aii->version >= 13 &&
             FIELD(sharedCacheSlide) == local_aii->sharedCacheSlide &&
             !memcmp(FIELD(sharedCacheUUID), local_aii->sharedCacheUUID, 16)) {

--- a/lib/darwin/macho.c
+++ b/lib/darwin/macho.c
@@ -1,0 +1,20 @@
+#include <stdint.h>
+#include <mach/mach.h>
+#include <darwin/macho.h>
+
+
+struct dyld_all_image_infos * my_get_all_image_infos()
+{
+    kern_return_t kr;
+    task_flavor_t flavor = TASK_DYLD_INFO;
+    task_dyld_info_data_t infoData;
+    mach_msg_type_number_t task_info_outCnt = TASK_DYLD_INFO_COUNT;
+    kr = task_info(mach_task_self(), flavor, (task_info_t) &infoData, &task_info_outCnt);
+    if (kr != KERN_SUCCESS) {
+        //KR_ERROR(kr);
+        return 0;
+    }
+    struct dyld_all_image_infos *allImageInfos =
+            (struct dyld_all_image_infos *) infoData.all_image_info_addr;
+    return allImageInfos;
+}

--- a/lib/darwin/macho.h
+++ b/lib/darwin/macho.h
@@ -1,0 +1,3 @@
+#include <stdint.h>
+#include <mach/mach.h>
+struct dyld_all_image_infos * my_get_all_image_infos();


### PR DESCRIPTION
When running on 10.13 or later, `_dyld_get_all_image_infos()` is not
available. It appears to still be implemented in dyld, but its symbol is
now private. This was always known to be an “internal” interface. When
it’s not available, fall back to obtaining the address of the process’
dyld_all_image_infos structure by calling task_info(…, TASK_DYLD_INFO,
…). 