### PR TITLE
Fix SubGetImageByName for iOS versions with ImageLoaderMegaDylib

### DIFF
--- a/lib/arm64/arch-dis.h
+++ b/lib/arm64/arch-dis.h
@@ -28,7 +28,7 @@ static inline void arch_dis_ctx_init(struct arch_dis_ctx *ctx) {
 }
 
 static inline int arm64_get_unwritten_temp_reg(struct arch_dis_ctx *ctx) {
-    uint32_t avail = ~ctx->regs_possibly_written & ((1 << 19) - (1 << 9));
+    uint32_t avail = ~ctx->regs_possibly_written & ((1 << 18) - (1 << 9));
     if (!avail)
         __builtin_abort();
     return 31 - __builtin_clz(avail);


### PR DESCRIPTION
Newer iOS versions with ImageLoaderMegaDylib segfault without this patch when you try to use SubGetImageByName because it actually has a "handle" that is not a memory address for shared cache images.  This makes it use the correct function in dyld.